### PR TITLE
Upgrade Native SDK Into 7.9.0 For Android and 7.9.1 For IOS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,5 +39,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // ironSource SDK
-    implementation 'com.ironsource.sdk:mediationsdk:7.3.0.1'
+    implementation 'com.ironsource.sdk:mediationsdk:7.9.0'
 }

--- a/ios/ironsource_mediation.podspec
+++ b/ios/ironsource_mediation.podspec
@@ -23,5 +23,5 @@ Mobile sdk for IronSource
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
   # ironSource
-  s.dependency 'IronSourceSDK','7.3.0'
+  s.dependency 'IronSourceSDK','7.9.1'
 end

--- a/lib/src/models/ironsource_ow_credit_info.dart
+++ b/lib/src/models/ironsource_ow_credit_info.dart
@@ -1,4 +1,3 @@
-import 'package:ironsource_mediation/ironsource_mediation.dart';
 
 /// Offerwall credit info wrapper
 @Deprecated(

--- a/lib/src/models/listeners/level_play_rewarded_video_base_listener.dart
+++ b/lib/src/models/listeners/level_play_rewarded_video_base_listener.dart
@@ -1,7 +1,6 @@
 import '../ironsource_rewardedvideo_placement.dart';
 import '../ironsource_error.dart';
 import '../ironsource_ad_info.dart';
-import '../ironsource_rv_placement.dart';
 
 abstract class LevelPlayRewardedVideoBaseListener {
   /// The Rewarded Video ad view has opened.

--- a/lib/src/models/listeners/rewarded_video_listener.dart
+++ b/lib/src/models/listeners/rewarded_video_listener.dart
@@ -1,6 +1,5 @@
 import '../ironsource_error.dart';
 import '../ironsource_rewardedvideo_placement.dart';
-import '../ironsource_rv_placement.dart';
 
 /// Rewarded Video
 @Deprecated(


### PR DESCRIPTION
In this pull request, I've upgraded the Native SDK to version 7.9.0 for Android and 7.9.1 for iOS. Additionally, I've removed some unused imports in the bridge for a cleaner codebase.